### PR TITLE
AuthManager 도입 및 ViewModel 리팩토링

### DIFF
--- a/GreenRoom.xcodeproj/project.pbxproj
+++ b/GreenRoom.xcodeproj/project.pbxproj
@@ -65,6 +65,12 @@
 		E470539528AB81EC00884B56 /* MyPageModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E470539428AB81EC00884B56 /* MyPageModel.swift */; };
 		E470539728AB856D00884B56 /* SettingHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = E470539628AB856D00884B56 /* SettingHeader.swift */; };
 		E470539928AB882900884B56 /* SettingRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = E470539828AB882900884B56 /* SettingRow.swift */; };
+		E48F8B4F28C26864007AAF40 /* AuthManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = E48F8B4E28C26864007AAF40 /* AuthManager.swift */; };
+		E48F8B5128C26BED007AAF40 /* APIManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = E48F8B5028C26BED007AAF40 /* APIManager.swift */; };
+		E49CC15628C326DA009216E1 /* EditProfileViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E49CC15528C326DA009216E1 /* EditProfileViewModel.swift */; };
+		E49CC16C28C331E4009216E1 /* SFPro.ttf in Resources */ = {isa = PBXBuildFile; fileRef = E49CC16A28C331E4009216E1 /* SFPro.ttf */; };
+		E49CC16D28C331E4009216E1 /* SFProText-Semibold.otf in Resources */ = {isa = PBXBuildFile; fileRef = E49CC16B28C331E4009216E1 /* SFProText-Semibold.otf */; };
+		E49CC16F28C331EA009216E1 /* SFProText-Bold.otf in Resources */ = {isa = PBXBuildFile; fileRef = E49CC16E28C331EA009216E1 /* SFProText-Bold.otf */; };
 		E49EF3D028B5361000358340 /* PopularHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = E49EF3CF28B5361000358340 /* PopularHeader.swift */; };
 		E49EF3D228B5375D00358340 /* Question.swift in Sources */ = {isa = PBXBuildFile; fileRef = E49EF3D128B5375D00358340 /* Question.swift */; };
 		E49EF3D428B5377900358340 /* GreenRoomSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = E49EF3D328B5377900358340 /* GreenRoomSection.swift */; };
@@ -72,15 +78,12 @@
 		E49EF3DC28B5E9AC00358340 /* GRSearchViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E49EF3DB28B5E9AC00358340 /* GRSearchViewController.swift */; };
 		E49F7D8928BC7D7E000AB49B /* CreateQuestionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E49F7D8828BC7D7E000AB49B /* CreateQuestionViewController.swift */; };
 		E4C4C4AE28BCA53D008826AB /* GreenRoomService.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4C4C4AD28BCA53D008826AB /* GreenRoomService.swift */; };
-		E4C4C4B828BCF6A9008826AB /* SFProText-Semibold.otf in Resources */ = {isa = PBXBuildFile; fileRef = E4C4C4B528BCF6A9008826AB /* SFProText-Semibold.otf */; };
-		E4C4C4BA28BCF6A9008826AB /* SFProText-Bold.otf in Resources */ = {isa = PBXBuildFile; fileRef = E4C4C4B728BCF6A9008826AB /* SFProText-Bold.otf */; };
 		E4C4C4BC28BD1172008826AB /* CustomTabbarController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4C4C4BB28BD1172008826AB /* CustomTabbarController.swift */; };
 		E4C4C4BE28BD1ACD008826AB /* CreatePopOverViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4C4C4BD28BD1ACD008826AB /* CreatePopOverViewController.swift */; };
 		E4C4C4C028BDE8AB008826AB /* CreateGreenRoomViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4C4C4BF28BDE8AB008826AB /* CreateGreenRoomViewController.swift */; };
 		E4C4C4C228BE029F008826AB /* CreateViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4C4C4C128BE029F008826AB /* CreateViewModel.swift */; };
 		E4C8AE6928B35519007E010D /* UserService.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4C8AE6828B35519007E010D /* UserService.swift */; };
 		E4C8AE6B28B35533007E010D /* User.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4C8AE6A28B35533007E010D /* User.swift */; };
-		E4F928BC28BFB65300C345C3 /* SFPro.ttf in Resources */ = {isa = PBXBuildFile; fileRef = E4F928BB28BFB65300C345C3 /* SFPro.ttf */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -147,6 +150,12 @@
 		E470539428AB81EC00884B56 /* MyPageModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyPageModel.swift; sourceTree = "<group>"; };
 		E470539628AB856D00884B56 /* SettingHeader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingHeader.swift; sourceTree = "<group>"; };
 		E470539828AB882900884B56 /* SettingRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingRow.swift; sourceTree = "<group>"; };
+		E48F8B4E28C26864007AAF40 /* AuthManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthManager.swift; sourceTree = "<group>"; };
+		E48F8B5028C26BED007AAF40 /* APIManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIManager.swift; sourceTree = "<group>"; };
+		E49CC15528C326DA009216E1 /* EditProfileViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditProfileViewModel.swift; sourceTree = "<group>"; };
+		E49CC16A28C331E4009216E1 /* SFPro.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = SFPro.ttf; sourceTree = "<group>"; };
+		E49CC16B28C331E4009216E1 /* SFProText-Semibold.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "SFProText-Semibold.otf"; sourceTree = "<group>"; };
+		E49CC16E28C331EA009216E1 /* SFProText-Bold.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "SFProText-Bold.otf"; sourceTree = "<group>"; };
 		E49EF3CF28B5361000358340 /* PopularHeader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PopularHeader.swift; sourceTree = "<group>"; };
 		E49EF3D128B5375D00358340 /* Question.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Question.swift; sourceTree = "<group>"; };
 		E49EF3D328B5377900358340 /* GreenRoomSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GreenRoomSection.swift; sourceTree = "<group>"; };
@@ -154,15 +163,12 @@
 		E49EF3DB28B5E9AC00358340 /* GRSearchViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GRSearchViewController.swift; sourceTree = "<group>"; };
 		E49F7D8828BC7D7E000AB49B /* CreateQuestionViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateQuestionViewController.swift; sourceTree = "<group>"; };
 		E4C4C4AD28BCA53D008826AB /* GreenRoomService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GreenRoomService.swift; sourceTree = "<group>"; };
-		E4C4C4B528BCF6A9008826AB /* SFProText-Semibold.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "SFProText-Semibold.otf"; sourceTree = "<group>"; };
-		E4C4C4B728BCF6A9008826AB /* SFProText-Bold.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "SFProText-Bold.otf"; sourceTree = "<group>"; };
 		E4C4C4BB28BD1172008826AB /* CustomTabbarController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomTabbarController.swift; sourceTree = "<group>"; };
 		E4C4C4BD28BD1ACD008826AB /* CreatePopOverViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreatePopOverViewController.swift; sourceTree = "<group>"; };
 		E4C4C4BF28BDE8AB008826AB /* CreateGreenRoomViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateGreenRoomViewController.swift; sourceTree = "<group>"; };
 		E4C4C4C128BE029F008826AB /* CreateViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateViewModel.swift; sourceTree = "<group>"; };
 		E4C8AE6828B35519007E010D /* UserService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserService.swift; sourceTree = "<group>"; };
 		E4C8AE6A28B35533007E010D /* User.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = User.swift; sourceTree = "<group>"; };
-		E4F928BB28BFB65300C345C3 /* SFPro.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = SFPro.ttf; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -281,7 +287,7 @@
 				DB563F9D28AE266D00E7193D /* CategoryViewModel.swift */,
 				DBD0823A2897E75A0092241F /* GreenViewModel.swift */,
 				DBD0823B2897E75A0092241F /* KeywordViewModel.swift */,
-				DBD0823C2897E75A0092241F /* MyPageViewModel.swift */,
+				E49CC15428C326CD009216E1 /* MyPage */,
 				E4C4C4C128BE029F008826AB /* CreateViewModel.swift */,
 			);
 			path = ViewModel;
@@ -396,9 +402,9 @@
 		DBD082612897E77F0092241F /* Font */ = {
 			isa = PBXGroup;
 			children = (
-				E4F928BB28BFB65300C345C3 /* SFPro.ttf */,
-				E4C4C4B728BCF6A9008826AB /* SFProText-Bold.otf */,
-				E4C4C4B528BCF6A9008826AB /* SFProText-Semibold.otf */,
+				E49CC16E28C331EA009216E1 /* SFProText-Bold.otf */,
+				E49CC16A28C331E4009216E1 /* SFPro.ttf */,
+				E49CC16B28C331E4009216E1 /* SFProText-Semibold.otf */,
 				E46539E628AD3F2800F17A6C /* SFProText-Regular.otf */,
 			);
 			path = Font;
@@ -447,6 +453,8 @@
 			isa = PBXGroup;
 			children = (
 				E40BC6FA28B892C400FB557D /* CoreDataManager.swift */,
+				E48F8B4E28C26864007AAF40 /* AuthManager.swift */,
+				E48F8B5028C26BED007AAF40 /* APIManager.swift */,
 			);
 			path = Manager;
 			sourceTree = "<group>";
@@ -478,6 +486,15 @@
 				E4141AB228AF4499004D74B3 /* Storage.swift */,
 			);
 			path = Utils;
+			sourceTree = "<group>";
+		};
+		E49CC15428C326CD009216E1 /* MyPage */ = {
+			isa = PBXGroup;
+			children = (
+				DBD0823C2897E75A0092241F /* MyPageViewModel.swift */,
+				E49CC15528C326DA009216E1 /* EditProfileViewModel.swift */,
+			);
+			path = MyPage;
 			sourceTree = "<group>";
 		};
 		E49EF3CE28B5360600358340 /* Popular */ = {
@@ -578,12 +595,12 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				E4C4C4BA28BCF6A9008826AB /* SFProText-Bold.otf in Resources */,
-				E4C4C4B828BCF6A9008826AB /* SFProText-Semibold.otf in Resources */,
+				E49CC16F28C331EA009216E1 /* SFProText-Bold.otf in Resources */,
 				E46539E928AD3F2800F17A6C /* SFProText-Regular.otf in Resources */,
-				E4F928BC28BFB65300C345C3 /* SFPro.ttf in Resources */,
 				DBD082262897E6F30092241F /* Assets.xcassets in Resources */,
 				DBD082292897E6F30092241F /* LaunchScreen.storyboard in Resources */,
+				E49CC16D28C331E4009216E1 /* SFProText-Semibold.otf in Resources */,
+				E49CC16C28C331E4009216E1 /* SFPro.ttf in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -668,6 +685,7 @@
 				DBD082572897E75B0092241F /* KeywordViewController.swift in Sources */,
 				DBA8ED6428B9D336007526CF /* RecentSearchKeyword+CoreDataClass.swift in Sources */,
 				DBA8ED6A28B9D621007526CF /* PracticeQuestionCell.swift in Sources */,
+				E49CC15628C326DA009216E1 /* EditProfileViewModel.swift in Sources */,
 				DBD082522897E75B0092241F /* GreenViewModel.swift in Sources */,
 				E49EF3DC28B5E9AC00358340 /* GRSearchViewController.swift in Sources */,
 				E4141ABC28AF528E004D74B3 /* FAQCell.swift in Sources */,
@@ -677,6 +695,7 @@
 				DBBA9481289968CD00264405 /* PaddingLabel.swift in Sources */,
 				DBD082542897E75B0092241F /* MyPageViewModel.swift in Sources */,
 				E4141ACB28AF79E7004D74B3 /* FAQViewController.swift in Sources */,
+				E48F8B4F28C26864007AAF40 /* AuthManager.swift in Sources */,
 				DBD082602897E7740092241F /* LoginService.swift in Sources */,
 				E49EF3D428B5377900358340 /* GreenRoomSection.swift in Sources */,
 				DBA8ED6628B9D347007526CF /* RecentSearchKeyword+CoreDataProperties.swift in Sources */,
@@ -701,6 +720,7 @@
 				E4141ACA28AF79E7004D74B3 /* QNAViewController.swift in Sources */,
 				DBD0825A2897E75B0092241F /* ProfileCell.swift in Sources */,
 				DBD082552897E75B0092241F /* GreenRoomViewController.swift in Sources */,
+				E48F8B5128C26BED007AAF40 /* APIManager.swift in Sources */,
 				DB563F9A28ABADDF00E7193D /* RxNaverThirdPartyLoginProxy.swift in Sources */,
 				DBD082562897E75B0092241F /* MyPageViewController.swift in Sources */,
 			);

--- a/GreenRoom.xcodeproj/project.pbxproj
+++ b/GreenRoom.xcodeproj/project.pbxproj
@@ -66,7 +66,6 @@
 		E470539728AB856D00884B56 /* SettingHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = E470539628AB856D00884B56 /* SettingHeader.swift */; };
 		E470539928AB882900884B56 /* SettingRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = E470539828AB882900884B56 /* SettingRow.swift */; };
 		E48F8B4F28C26864007AAF40 /* AuthManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = E48F8B4E28C26864007AAF40 /* AuthManager.swift */; };
-		E48F8B5128C26BED007AAF40 /* APIManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = E48F8B5028C26BED007AAF40 /* APIManager.swift */; };
 		E49CC15628C326DA009216E1 /* EditProfileViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E49CC15528C326DA009216E1 /* EditProfileViewModel.swift */; };
 		E49CC16C28C331E4009216E1 /* SFPro.ttf in Resources */ = {isa = PBXBuildFile; fileRef = E49CC16A28C331E4009216E1 /* SFPro.ttf */; };
 		E49CC16D28C331E4009216E1 /* SFProText-Semibold.otf in Resources */ = {isa = PBXBuildFile; fileRef = E49CC16B28C331E4009216E1 /* SFProText-Semibold.otf */; };
@@ -151,7 +150,6 @@
 		E470539628AB856D00884B56 /* SettingHeader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingHeader.swift; sourceTree = "<group>"; };
 		E470539828AB882900884B56 /* SettingRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingRow.swift; sourceTree = "<group>"; };
 		E48F8B4E28C26864007AAF40 /* AuthManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthManager.swift; sourceTree = "<group>"; };
-		E48F8B5028C26BED007AAF40 /* APIManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIManager.swift; sourceTree = "<group>"; };
 		E49CC15528C326DA009216E1 /* EditProfileViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditProfileViewModel.swift; sourceTree = "<group>"; };
 		E49CC16A28C331E4009216E1 /* SFPro.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = SFPro.ttf; sourceTree = "<group>"; };
 		E49CC16B28C331E4009216E1 /* SFProText-Semibold.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "SFProText-Semibold.otf"; sourceTree = "<group>"; };
@@ -454,7 +452,6 @@
 			children = (
 				E40BC6FA28B892C400FB557D /* CoreDataManager.swift */,
 				E48F8B4E28C26864007AAF40 /* AuthManager.swift */,
-				E48F8B5028C26BED007AAF40 /* APIManager.swift */,
 			);
 			path = Manager;
 			sourceTree = "<group>";
@@ -720,7 +717,6 @@
 				E4141ACA28AF79E7004D74B3 /* QNAViewController.swift in Sources */,
 				DBD0825A2897E75B0092241F /* ProfileCell.swift in Sources */,
 				DBD082552897E75B0092241F /* GreenRoomViewController.swift in Sources */,
-				E48F8B5128C26BED007AAF40 /* APIManager.swift in Sources */,
 				DB563F9A28ABADDF00E7193D /* RxNaverThirdPartyLoginProxy.swift in Sources */,
 				DBD082562897E75B0092241F /* MyPageViewController.swift in Sources */,
 			);

--- a/GreenRoom/AppDelegate.swift
+++ b/GreenRoom/AppDelegate.swift
@@ -81,7 +81,7 @@ extension AppDelegate {
     }
     
     func setLoginAttributes(){
-        KakaoSDK.initSDK(appKey: Storage().kakaoAppKey) //Kakao SDK Init
+        KakaoSDK.initSDK(appKey: Storage.kakaoAppKey) //Kakao SDK Init
         //Naver
         let instance = NaverThirdPartyLoginConnection.getSharedInstance()
         

--- a/GreenRoom/Controller/MyPage/EditProfileInfoViewController.swift
+++ b/GreenRoom/Controller/MyPage/EditProfileInfoViewController.swift
@@ -6,11 +6,15 @@
 //
 import UIKit
 import RxSwift
+import RxCocoa
 
+protocol EditProfileInfoDelegate {
+    func editNickName(textField: Observable<String>)
+}
 class EditProfileInfoViewController: BaseViewController {
     
     //MARK: - properties
-    private let viewModel: MyPageViewModel
+    private let viewModel: EditProfileViewModel
     
     private let nameLabel = UILabel().then{
         $0.text = "이름"
@@ -34,7 +38,7 @@ class EditProfileInfoViewController: BaseViewController {
         configuration.imagePadding = 230
         configuration.imagePlacement = .trailing
         configuration.baseForegroundColor = .black
-        configuration.contentInsets = NSDirectionalEdgeInsets(top: 0, leading: 46, bottom: 0, trailing: 63)
+        configuration.contentInsets = NSDirectionalEdgeInsets(top: 0, leading: 30, bottom: 0, trailing: 63)
         $0.titleLabel?.font = .sfPro(size: 16, family: .Regular)
         $0.addTarget(self, action: #selector(didTapLogout), for: .touchUpInside)
         $0.imageView?.tintColor = .black
@@ -58,7 +62,7 @@ class EditProfileInfoViewController: BaseViewController {
     }
     
     //MARK: - lifecycle
-    init(viewModel: MyPageViewModel){
+    init(viewModel: EditProfileViewModel){
         self.viewModel = viewModel
         super.init(nibName: nil, bundle: nil)
     }
@@ -112,10 +116,11 @@ class EditProfileInfoViewController: BaseViewController {
     }
     
     override func setupBinding() {
+        let input = EditProfileViewModel.Input(trigger: self.rx.viewWillAppear.asObservable())
         
-        viewModel.usernameObservable.subscribe(onNext: { [weak self] name in
-            self?.nameTextField.text = name
-        }).disposed(by: disposeBag)
+        let output = viewModel.transform(input: input)
+        
+        output.userName.bind(to: self.nameTextField.rx.text).disposed(by: disposeBag)
         
         nameTextField.rx.controlEvent(.editingDidEndOnExit)
             .subscribe(onNext: { [weak self] _ in
@@ -128,7 +133,7 @@ class EditProfileInfoViewController: BaseViewController {
     }
     
     @objc func didTapLogout(){
-//        nameTextField.rx.bind()
+        //        nameTextField.rx.bind()
     }
     
     @objc func didTapWithdrawal(){

--- a/GreenRoom/Manager/AuthManager.swift
+++ b/GreenRoom/Manager/AuthManager.swift
@@ -1,0 +1,54 @@
+//
+//  AuthManager.swift
+//  GreenRoom
+//
+//  Created by Doyun Park on 2022/09/03.
+//
+
+import Alamofire
+import SwiftKeychainWrapper
+
+class AuthManager: RequestInterceptor {
+    
+    func adapt(_ urlRequest: URLRequest, for session: Session, completion: @escaping (Result<URLRequest, Error>) -> Void) {
+        
+        guard urlRequest.url?.absoluteString.hasPrefix(Storage.baseURL) == true,
+              let accessToken = KeychainWrapper.standard.string(forKey: "accessToken") else { return }
+        
+        var urlRequest = urlRequest
+        urlRequest.headers.add(.authorization(bearerToken: accessToken))
+        
+        completion(.success(urlRequest))
+    }
+    
+    func retry(_ request: Request, for session: Session, dueTo error: Error, completion: @escaping (RetryResult) -> Void) {
+        guard let response = request.task?.response as? HTTPURLResponse, response.statusCode == 401 else {
+            completion(.doNotRetryWithError(error))
+            return
+        }
+        
+        guard let url = URL(string: "\(Storage.baseURL)/api/auth/reissue") else { return }
+        
+        guard let accessToken = KeychainWrapper.standard.string(forKey: "accessToten"), let refreshToken = KeychainWrapper.standard.string(forKey: "refreshToken") else { return }
+        
+        let headers: HTTPHeaders = [
+            "accessToken": accessToken,
+            "refreshToken": refreshToken
+        ]
+        
+        AF.request(url,method: .post, encoding: JSONEncoding.default, headers: headers).responseDecodable(of: LoginModel.self) {
+            response in
+            
+            switch response.result {
+            case .success(let token):
+                print("token 재발급 완료")
+                KeychainWrapper.standard.removeAllKeys()
+                KeychainWrapper.standard.set(token.refreshToken, forKey: "RefreshToken")
+                KeychainWrapper.standard.set(token.accessToken, forKey: "AccessToken")
+            case .failure(let error):
+                completion(.doNotRetryWithError(error))
+            }
+        }
+        
+    }
+}

--- a/GreenRoom/Services/GreenRoomService.swift
+++ b/GreenRoom/Services/GreenRoomService.swift
@@ -13,7 +13,7 @@ import RxCocoa
 final class GreenRoomService {
     
     func fetchPopularKeywords(completion:@escaping (Result<[String],Error>) -> Void){
-        guard let url = URL(string: "\(Storage().baseURL)/api/public-questions/popular-search-words") else { return }
+        guard let url = URL(string: "\(Storage.baseURL)/api/public-questions/popular-search-words") else { return }
         
         guard let accessToken = KeychainWrapper.standard.string(forKey: "accessToken") else {
             return

--- a/GreenRoom/Services/LoginService.swift
+++ b/GreenRoom/Services/LoginService.swift
@@ -15,7 +15,7 @@ import SwiftKeychainWrapper
 class LoginService{
     
     func loginAPI(_ accessToken: String, authType: Int)->Observable<LoginModel> {
-        let urlString = Storage().baseURL + "/api/auth/login"
+        let urlString = Storage.baseURL + "/api/auth/login"
         let url = URL(string: urlString)!
         
         let param: Parameters = [
@@ -41,7 +41,7 @@ class LoginService{
     }
     
     static func registUser(accessToken: String, oauthType: Int, category: Int, name: String){
-        let urlString = Storage().baseURL + "/api/users/join"
+        let urlString = Storage.baseURL + "/api/users/join"
         let url = URL(string: urlString)!
         
         let param: Parameters = [
@@ -70,7 +70,7 @@ class LoginService{
             "Authorization": "Bearer \(accessToken)"
         ]
         
-        let urlString = Storage().baseURL + "/api/auth/logout"
+        let urlString = Storage.baseURL + "/api/auth/logout"
         let url = URL(string: urlString)!
         
         return Observable.create{ emitter in
@@ -91,7 +91,7 @@ class LoginService{
     }
     
     static func checkName(name: String) -> Observable<Bool> {
-        let urlString = Storage().baseURL + "/api/users/name"
+        let urlString = Storage.baseURL + "/api/users/name"
         let url = URL(string: urlString)!
         
         let param: Parameters = [

--- a/GreenRoom/Services/LoginService.swift
+++ b/GreenRoom/Services/LoginService.swift
@@ -72,16 +72,15 @@ class LoginService{
         
         let urlString = Storage.baseURL + "/api/auth/logout"
         let url = URL(string: urlString)!
-        
         return Observable.create{ emitter in
-            let req = AF.request(url, method: .post, headers: headers).validate(statusCode: 200..<300)
-            
-            req.response() { res in
-                switch res.result {
+            AF.request(url, method: .post, headers: headers,interceptor: AuthManager()).validate().response { response in
+                switch response.result {
                 case .success(_):
+                    print("성공")
                     emitter.onNext(true)
                     emitter.onCompleted()
                 case .failure(let error):
+                    print(error.localizedDescription)
                     emitter.onError(error)
                 }
             }

--- a/GreenRoom/Services/QuestionService.swift
+++ b/GreenRoom/Services/QuestionService.swift
@@ -32,16 +32,11 @@ final class QuestionService {
         
         print("DEBUG: \(categoryId),, \(question)")
         let url = URL(string: "\(Storage.baseURL)/api/private-questions")!
-        let accessToken = KeychainWrapper.standard.string(forKey: "accessToken")!
-        
-        let headers: HTTPHeaders = [
-            "Authorization": "Bearer \(accessToken)"
-        ]
         
         let parameters = UploadQuestionModel(categoryId: categoryId, question: question)
         
         return Observable.create { emitter in
-            AF.request(url, method: .post, parameters: parameters, encoder: .json, headers: headers).responseData { response in
+            AF.request(url, method: .post, parameters: parameters, encoder: .json, interceptor: AuthManager()).responseData { response in
                 switch response.result {
                 case .success(_):
                     if response.response?.statusCode == 400 {

--- a/GreenRoom/Services/QuestionService.swift
+++ b/GreenRoom/Services/QuestionService.swift
@@ -31,7 +31,7 @@ final class QuestionService {
     func uploadQuestionList(categoryId: Int, question: String) -> Observable<Bool> {
         
         print("DEBUG: \(categoryId),, \(question)")
-        let url = URL(string: "\(Storage().baseURL)/api/private-questions")!
+        let url = URL(string: "\(Storage.baseURL)/api/private-questions")!
         let accessToken = KeychainWrapper.standard.string(forKey: "accessToken")!
         
         let headers: HTTPHeaders = [

--- a/GreenRoom/Services/UserService.swift
+++ b/GreenRoom/Services/UserService.swift
@@ -37,23 +37,6 @@ enum ImageType {
 class UserService {
     
     //MARK: - 회원정보 조회
-    //    func fetchUserInfo() -> Observable<[MyPageSectionModel]> {
-    //        return Observable.create { [weak self] emmiter in
-    //            self?.fetchUserInfo(completion: { result in
-    //                switch result {
-    //                case .success(let user):
-    //                    let userModel = MyPageSectionModel.profile(items: [
-    //                        MyPageSectionModel.Item.profile(profileInfo: user)
-    //                    ])
-    //                    emmiter.onNext([userModel])
-    //                case .failure(let error):
-    //                    emmiter.onError(error)
-    //                }
-    //            })
-    //            return Disposables.create()
-    //        }
-    //    }
-    
     func fetchUserInfo() -> Observable<User> {
         let url = URL(string: Storage.baseURL + "/api/users")!
         
@@ -116,16 +99,8 @@ extension UserService {
             return
             
         }
-        
-        guard let accessToken = KeychainWrapper.standard.string(forKey: "accessToken") else {
-            return
-        }
-        
-        let headers: HTTPHeaders = [
-            "Authorization": "Bearer \(accessToken)"
-        ]
-        
-        AF.request(url, method: .put, parameters: parameters, encoder: .json, headers: headers).validate(statusCode: 200..<300).responseDecodable(of: PresignedURL.self) { response in
+
+        AF.request(url, method: .put, parameters: parameters, encoder: .json, interceptor: AuthManager()).validate(statusCode: 200..<300).responseDecodable(of: PresignedURL.self) { response in
             switch response.result {
             case .success(let url):
                 completion(url.profileImage)
@@ -155,15 +130,8 @@ extension UserService {
     func updateUserInfo(parameter: [String: Any], completion: @escaping(Bool) -> Void) {
         guard let url = URL(string: Storage.baseURL + "/api/users") else { return }
         
-        guard let accessToken = KeychainWrapper.standard.string(forKey: "accessToken") else {
-            return
-        }
-        
-        let headers: HTTPHeaders = [
-            "Authorization": "Bearer \(accessToken)"
-        ]
         if let name = parameter as? [String: String] {
-            AF.request(url, method: .put,parameters: name, encoder: JSONParameterEncoder.default , headers: headers).validate(statusCode: 200..<300).response { response in
+            AF.request(url, method: .put,parameters: name, encoder: JSONParameterEncoder.default, interceptor: AuthManager()).validate(statusCode: 200..<300).response { response in
                 switch response.result {
                 case .success(_):
                     print("Success to upload user info")
@@ -175,7 +143,7 @@ extension UserService {
                 
             }
         } else if let category = parameter as? [String: Int] {
-            AF.request(url, method: .put,parameters: category, encoder: JSONParameterEncoder.default , headers: headers).validate(statusCode: 200..<300).response { response in
+            AF.request(url, method: .put,parameters: category, encoder: JSONParameterEncoder.default, interceptor: AuthManager()).validate(statusCode: 200..<300).response { response in
                 switch response.result {
                 case .success(_):
                     print("Success to upload user info")

--- a/GreenRoom/Utils/Storage.swift
+++ b/GreenRoom/Utils/Storage.swift
@@ -9,7 +9,7 @@ import Foundation
 
 struct Storage {
     
-    let kakaoAppKey = "a45de08bf74de9630747bd72021eb355"
+    static let kakaoAppKey = "a45de08bf74de9630747bd72021eb355"
     
-    let baseURL = "https://green-room.link"
+    static let baseURL = "https://green-room.link"
 }

--- a/GreenRoom/ViewModel/CreateViewModel.swift
+++ b/GreenRoom/ViewModel/CreateViewModel.swift
@@ -47,7 +47,6 @@ final class CreateViewModel: ViewModelType {
         input.submit.withLatestFrom(Observable.zip(input.question, input.category.map { String($0) }))
             .flatMapLatest { (question, category) -> Observable<Bool> in
                 return self.questionService.uploadQuestionList(categoryId: Int(category)!, question: question)
-//                self?.questionService.uploadQuestionList(categoryId: Int(category)!, question: question)
             }.subscribe { _ in
                 self.successMessage.accept("질문 작성이 완료되었어요!")
             } onError: { error in

--- a/GreenRoom/ViewModel/MyPage/EditProfileViewModel.swift
+++ b/GreenRoom/ViewModel/MyPage/EditProfileViewModel.swift
@@ -1,0 +1,47 @@
+//
+//  EditProfileViewModel.swift
+//  GreenRoom
+//
+//  Created by Doyun Park on 2022/09/03.
+//
+
+import RxSwift
+
+final class EditProfileViewModel: ViewModelType {
+
+    private let userService: UserService
+    
+    struct Input{
+        let trigger: Observable<Bool>
+    }
+
+    struct Output {
+        let userName: Observable<String>
+    }
+
+    var disposeBag = DisposeBag()
+    
+    init(userService: UserService){
+        self.userService = userService
+    }
+    
+    func transform(input: Input) -> Output {
+        return Output(userName: input.trigger.flatMap { _ in
+            return self.userService.fetchUserInfo()
+        }.map {
+            print($0.name)
+            return $0.name
+        })
+    }
+    
+    func updateUserInfo(nickName: String) {
+        let parameter = [
+            "name" : nickName
+        ]
+
+        self.userService.updateUserInfo(parameter: parameter) { _ in
+            print("업데이트에 성공했습니다.")
+        }
+
+    }
+}

--- a/GreenRoom/ViewModel/MyPage/MyPageViewModel.swift
+++ b/GreenRoom/ViewModel/MyPage/MyPageViewModel.swift
@@ -10,19 +10,22 @@ import UIKit
 import RxSwift
 import RxCocoa
 
-class MyPageViewModel {
+class MyPageViewModel: ViewModelType {
+
+    struct Input {
+        let viewTrigger: Observable<Bool>
+        let profileImage: Observable<UIImage?>
+    }
+    
+    struct Output {
+        var MyPageDataSource: Observable<[MyPageSectionModel]>
+    }
     
     let userService = UserService()
-    
-    private var disposeBag = DisposeBag()
+    var disposeBag = DisposeBag()
     
     //MARK: - MyPageViewController
-//    let signal = PublishRelay<Void>()
-    
-    var userObservable = BehaviorSubject<[MyPageSectionModel]>(value: [])
-    var profileImageObservable = PublishSubject<UIImage?>()
-    var MyPageDataSource = BehaviorSubject<[MyPageSectionModel]>(value:[])
-    var usernameObservable = BehaviorSubject<String>(value: "")
+    private let userObservable = BehaviorSubject<[MyPageSectionModel]>(value: [MyPageSectionModel.profile(items: [MyPageSectionModel.Item.profile(profileInfo: User(categoryID: 1, category: "공통", name: "박면접", profileImage: ""))])])
 
     private let settingsObservable = Observable<[MyPageSectionModel]>.create { observer in
         observer.onNext(
@@ -41,12 +44,28 @@ class MyPageViewModel {
         return Disposables.create()
     }
     
-    
-    //MARK: - QNAViewController
-    private let defaultQNAImage = Observable<UIImage?>.create { observer in
-        observer.onNext(UIImage(systemName: "plus.circle"))
-        return Disposables.create()
+    func transform(input: Input) -> Output {
+        input.viewTrigger.flatMap { _ in
+            return self.userService.fetchUserInfo()
+        }.map {
+            return [MyPageSectionModel.profile(items: [
+                MyPageSectionModel.Item.profile(profileInfo: $0)
+            ])]
+        }.bind(to: self.userObservable).disposed(by: disposeBag)
+
+        input.profileImage.subscribe(onNext: { [weak self] image in
+            self?.updateProfileImage(image: image)
+        }).disposed(by: disposeBag)
+        
+//        input.userName.subscribe(onNext: { [weak self] name in
+//            self?.updateUserInfo(nickName: name)
+//        }).disposed(by: disposeBag)
+        
+//        let combine = Observable.combineLatest(userObservable, settingsObservable).map{ $0.0 + $0.1}
+        return Output(MyPageDataSource: Observable.combineLatest(userObservable, settingsObservable).map{ $0.0 + $0.1})
     }
+    //MARK: - QNAViewController
+    private let defaultQNAImage = Observable<UIImage?>.of(UIImage(systemName: "plus.circle"))
     
     //MARK: - FAQ
     var shownFAQ = BehaviorSubject<[FAQ]>(value: [])
@@ -86,67 +105,20 @@ class MyPageViewModel {
                     6. 타인의 답변을 베껴 작성하는 행위는 삼가해주세요.
                     """)
     ]
-    init(){
-        self.bind()
-    }
-    func bind(){
-        loadUserInfo()
-        
-        profileImageObservable.subscribe(onNext: { [weak self] image in
-            self?.userService.updateProfileImage(image: image) { completeUpload in
-                if completeUpload {
-                    self?.loadUserInfo()
-                }
-                
-            }
-        }).disposed(by: disposeBag)
-        
     
-        Observable.combineLatest(userObservable.asObserver(), settingsObservable.asObservable())
-            .subscribe(onNext: { [weak self] datasource in
-            self?.MyPageDataSource.onNext(datasource.0 + datasource.1)
-        }).disposed(by: disposeBag)
-    }
-    
-    //MARK: - fetchUserinfo
-    private func loadUserInfo(){
-        
-        self.userService.fetchUserInfo() { [weak self] result in
-            switch result {
-            case .success(let user):
-                
-                UserDefaults.standard.set(user.categoryID, forKey: "CategoryID")
-                
-                let userModel = MyPageSectionModel.profile(items: [
-                    MyPageSectionModel.Item.profile(profileInfo: user)
-                ])
-                self?.usernameObservable.onNext(user.name)
-                self?.userObservable.onNext([userModel])
-            case .failure(let error):
-                print(error)
-            }
+    private func fetchUserInfo() -> Observable<[MyPageSectionModel]> {
+        return self.userService.fetchUserInfo().compactMap {
+            return [MyPageSectionModel.profile(items: [
+                MyPageSectionModel.Item.profile(profileInfo: $0)
+            ])]
         }
     }
-    
     //MARK: - update user info
-    func updateUserInfo(nickName: String? = nil, cateogryId: Int? = nil) {
-        var parameter: [String: Any] = [:]
-        
-        if let nickName = nickName {
-            parameter["name"] = nickName
+    private func updateProfileImage(image: UIImage?){
+        self.userService.updateProfileImage(image: image) { [weak self] _ in
+            guard let self = self else { return }
+            self.fetchUserInfo().bind(to: self.userObservable).disposed(by: self.disposeBag)
         }
-        
-        if let cateogryId = cateogryId {
-            parameter["categoryId"] = cateogryId
-        }
-        
-        self.userService.updateUserInfo(parameter: parameter) { [weak self] isCompleted in
-            if isCompleted {
-                self?.loadUserInfo()
-            }
-            
-        }
-
     }
 }
 

--- a/GreenRoom/ViewModel/MyPage/MyPageViewModel.swift
+++ b/GreenRoom/ViewModel/MyPage/MyPageViewModel.swift
@@ -57,11 +57,6 @@ class MyPageViewModel: ViewModelType {
             self?.updateProfileImage(image: image)
         }).disposed(by: disposeBag)
         
-//        input.userName.subscribe(onNext: { [weak self] name in
-//            self?.updateUserInfo(nickName: name)
-//        }).disposed(by: disposeBag)
-        
-//        let combine = Observable.combineLatest(userObservable, settingsObservable).map{ $0.0 + $0.1}
         return Output(MyPageDataSource: Observable.combineLatest(userObservable, settingsObservable).map{ $0.0 + $0.1})
     }
     //MARK: - QNAViewController

--- a/Podfile
+++ b/Podfile
@@ -16,4 +16,5 @@ target 'GreenRoom' do
 	pod 'SwiftKeychainWrapper'
 	pod 'RxDataSources', '~> 5.0'
   pod 'Kingfisher', '~> 7.0'
+  pod 'RxViewController'
 end

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -46,6 +46,9 @@ PODS:
   - RxRelay (6.5.0):
     - RxSwift (= 6.5.0)
   - RxSwift (6.5.0)
+  - RxViewController (2.0.0):
+    - RxCocoa (~> 6.0)
+    - RxSwift (~> 6.0)
   - SnapKit (5.0.1)
   - SwiftKeychainWrapper (4.0.1)
   - Then (3.0.0)
@@ -58,6 +61,7 @@ DEPENDENCIES:
   - RxKakaoSDKAuth
   - RxKakaoSDKUser
   - RxSwift (= 6.5.0)
+  - RxViewController
   - SnapKit (~> 5.0.0)
   - SwiftKeychainWrapper
   - Then
@@ -79,6 +83,7 @@ SPEC REPOS:
     - RxKakaoSDKUser
     - RxRelay
     - RxSwift
+    - RxViewController
     - SnapKit
     - SwiftKeychainWrapper
     - Then
@@ -99,10 +104,11 @@ SPEC CHECKSUMS:
   RxKakaoSDKUser: 81a8735e0df352003d22a1bf3ad5a45bce9b471b
   RxRelay: 1de1523e604c72b6c68feadedd1af3b1b4d0ecbd
   RxSwift: 5710a9e6b17f3c3d6e40d6e559b9fa1e813b2ef8
+  RxViewController: 56486fa0afd629a1d6b5ba077f3b8cd9dc31b5d2
   SnapKit: 97b92857e3df3a0c71833cce143274bf6ef8e5eb
   SwiftKeychainWrapper: 807ba1d63c33a7d0613288512399cd1eda1e470c
   Then: 844265ae87834bbe1147d91d5d41a404da2ec27d
 
-PODFILE CHECKSUM: d8efef53204b796344422e830f832be2553cdb07
+PODFILE CHECKSUM: 2a91fa2b733f2d2e3a68ddb4f22cf9a55126dac7
 
 COCOAPODS: 1.11.3


### PR DESCRIPTION
## Authmanager 도입
- RequestInterceptor채택한 AuthManager를 통해 accept, retry 구현
- accept: 헤더에 토큰 자동으로 삽입
- retry: 401에러 발생시 refreshToken으로 재발급 받고 다시 원래 api호출

## ViewModel 리팩토링
- MyPageViewModel에서 수정을 클릭했을 때 발생하는 ViewModel 분리